### PR TITLE
Make Garden-of-Eden great again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on:
-  push:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   formatting:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.dev
-    command: npm run dev
+    command: sh -c "rm -f /tmp/nitro/*.sock && npm run dev"
     volumes:
       - .:/src
       - node_modules:/src/node_modules

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -30,10 +30,10 @@
             <ClientOnly>
               <ToggleInput
                 class="inline-block w-[5.1rem]"
-                :model-value="$colorMode.preference === 'mint'"
-                :label="$colorMode.preference === 'mint' ? 'Mint' : 'Dark'"
+                :model-value="$colorMode.preference === 'dark'"
+                :label="$colorMode.preference === 'dark' ? 'Dark' : 'Mint'"
                 @update:model-value="
-                  $colorMode.preference = $event ? 'mint' : 'dark'
+                  $colorMode.preference = $event ? 'dark' : 'mint'
                 "
               />
               <template #fallback>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,6 +74,7 @@ export default defineNuxtConfig({
   },
   colorMode: {
     classSuffix: '',
+    preference: 'dark',
   },
   cron: {
     runOnInit: false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:unit": "vitest",
     "ts:check": "nuxi typecheck",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "dev:docker": "docker-compose -f docker-compose.dev.yml up",
+    "dev:docker:cleanup": "docker-compose down --rmi all --remove-orphans"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.6.0",


### PR DESCRIPTION
Description to appease Eden

- Updated workflow from on push to pullrequests on master
- Fixed EADDRINUSE for nitro socket when restarting docker-compose
- Re-set Dark mode back to the right side as all is right in UI
- set Default colour mode to dark to avoid `system`
- Added docker scripts to package.json