### PR TITLE
add info for dynamic banner

### DIFF
--- a/pages/share.vue
+++ b/pages/share.vue
@@ -132,13 +132,14 @@
           <span class="italic text-sm">Mu-Cephei</span>
 
           <div v-if="authData?.user" class="space-y-2">
-            <div
+            <p
               class="flex items-center bg-green-500 dark:bg-neutral-800 border-transparent rounded-md p-4 max-w-prose mx-auto text-sm"
             >
-              The above banner is an example. Your banner will display any eggs and
-              hatchlings you currently have in the garden. If you have a flair, it'll be shown alongside your username. It
-              updates at a minimum of every 30 minutes.
-            </div>
+              The above banner is an example. Your banner will display any eggs
+              and hatchlings you currently have in the garden. If you have a
+              flair, it'll be shown alongside your username. It updates at a
+              minimum of every 30 minutes.
+            </p>
 
             <div class="flex items-center gap-2">
               <label for="animated-327x61-direct">Direct:</label>

--- a/pages/share.vue
+++ b/pages/share.vue
@@ -135,8 +135,8 @@
             <div
               class="flex items-center bg-green-500 dark:bg-neutral-800 border-transparent rounded-md p-4 max-w-prose mx-auto text-sm"
             >
-              The above banner is an example. The banner displays any eggs and
-              hatchlings you currently have present in the Garden of Eden. It
+              The above banner is an example. Your banner will display any eggs and
+              hatchlings you currently have in the garden. If you have a flair, it'll be shown alongside your username. It
               updates at a minimum of every 30 minutes.
             </div>
 

--- a/pages/share.vue
+++ b/pages/share.vue
@@ -130,8 +130,12 @@
             alt="animated 327x61 banner by Mu-Cephei"
           />
           <span class="italic text-sm">Mu-Cephei</span>
-          <p class="italic text-xs self-center">The above is an example.</p>
+
           <div v-if="authData?.user" class="space-y-2">
+            <div class="flex items-center bg-green-500 dark:bg-neutral-800 border-transparent rounded-md p-4 max-w-prose mx-auto text-sm">
+              The above banner is an example. The banner displays any eggs and hatchlings you currently have present in the Garden of Eden. It updates at a minimum of every 30 minutes.
+            </div>
+
             <div class="flex items-center gap-2">
               <label for="animated-327x61-direct">Direct:</label>
               <input

--- a/pages/share.vue
+++ b/pages/share.vue
@@ -132,8 +132,12 @@
           <span class="italic text-sm">Mu-Cephei</span>
 
           <div v-if="authData?.user" class="space-y-2">
-            <div class="flex items-center bg-green-500 dark:bg-neutral-800 border-transparent rounded-md p-4 max-w-prose mx-auto text-sm">
-              The above banner is an example. The banner displays any eggs and hatchlings you currently have present in the Garden of Eden. It updates at a minimum of every 30 minutes.
+            <div
+              class="flex items-center bg-green-500 dark:bg-neutral-800 border-transparent rounded-md p-4 max-w-prose mx-auto text-sm"
+            >
+              The above banner is an example. The banner displays any eggs and
+              hatchlings you currently have present in the Garden of Eden. It
+              updates at a minimum of every 30 minutes.
             </div>
 
             <div class="flex items-center gap-2">


### PR DESCRIPTION
A section of text under the dynamic banner that briefly explains which dragons the banner uses and how often it will generate.

Not sure whether you're moving forward with your hourly gen idea, so this text reflects how gen currently works.