### PR TITLE
Animated banners: use webp over gif

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "nuxt-security": "^2.1.1",
         "ofetch": "^1.4.1",
         "sharp": "^0.33.5",
-        "sharp-gif2": "^0.1.3",
         "vue": "latest",
         "vue-chartjs": "^5.3.1",
         "vue3-toastify": "^0.2.2",
@@ -9497,12 +9496,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/gifenc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
-      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
-      "license": "MIT"
-    },
     "node_modules/giget": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.3.tgz",
@@ -13756,16 +13749,6 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
-      }
-    },
-    "node_modules/sharp-gif2": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/sharp-gif2/-/sharp-gif2-0.1.3.tgz",
-      "integrity": "sha512-fJPrZlwoslUrgvOf5ZtE/v06qkki6vKblC4zF2QO70NqQ7RWKoHtGQCcg0s3rJa5colozwjry0nGsokrHcd2YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "gifenc": "*",
-        "sharp": "*"
       }
     },
     "node_modules/shebang-command": {
@@ -22574,11 +22557,6 @@
         "resolve-pkg-maps": "^1.0.0"
       }
     },
-    "gifenc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
-      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw=="
-    },
     "giget": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.3.tgz",
@@ -25522,15 +25500,6 @@
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
         "semver": "^7.6.3"
-      }
-    },
-    "sharp-gif2": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/sharp-gif2/-/sharp-gif2-0.1.3.tgz",
-      "integrity": "sha512-fJPrZlwoslUrgvOf5ZtE/v06qkki6vKblC4zF2QO70NqQ7RWKoHtGQCcg0s3rJa5colozwjry0nGsokrHcd2YQ==",
-      "requires": {
-        "gifenc": "*",
-        "sharp": "^0.33.5"
       }
     },
     "shebang-command": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "mariadb": "^3.3.1",
         "mysql2": "^3.11.0",
         "next-auth": "^4.21.1",
+        "node-webpmux": "^3.2.0",
         "nuxt": "^3.14.159",
         "nuxt-security": "^2.1.1",
         "ofetch": "^1.4.1",
@@ -11466,6 +11467,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "license": "MIT"
+    },
+    "node_modules/node-webpmux": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-webpmux/-/node-webpmux-3.2.0.tgz",
+      "integrity": "sha512-Rmc7MIS7zxDRPkfC9B15malsd1uStX2N6mYqHZNZeCJAVRDjmnxxTsyDh6POvWdNC7nmAYBW6CcHVY62DlnzRg=="
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -23977,6 +23983,11 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+    },
+    "node-webpmux": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-webpmux/-/node-webpmux-3.2.0.tgz",
+      "integrity": "sha512-Rmc7MIS7zxDRPkfC9B15malsd1uStX2N6mYqHZNZeCJAVRDjmnxxTsyDh6POvWdNC7nmAYBW6CcHVY62DlnzRg=="
     },
     "nopt": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mariadb": "^3.3.1",
     "mysql2": "^3.11.0",
     "next-auth": "^4.21.1",
+    "node-webpmux": "^3.2.0",
     "nuxt": "^3.14.159",
     "nuxt-security": "^2.1.1",
     "ofetch": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "nuxt-security": "^2.1.1",
     "ofetch": "^1.4.1",
     "sharp": "^0.33.5",
-    "sharp-gif2": "^0.1.3",
     "vue": "latest",
     "vue-chartjs": "^5.3.1",
     "vue3-toastify": "^0.2.2",

--- a/server/routes/share/scroll/[request].ts
+++ b/server/routes/share/scroll/[request].ts
@@ -193,6 +193,10 @@ export default defineEventHandler(async (event) => {
 
   if (!match || !query.success) return setResponseStatus(event, 404);
 
+  // Don't support gif anymore. But we're keeping this code
+  // in case we want to support it or other formats in the future.
+  query.data.ext = '.webp';
+
   const [, userId, username] = match;
 
   const params = await paramSchema.safeParseAsync({

--- a/workers/shareScroll.worker.ts
+++ b/workers/shareScroll.worker.ts
@@ -13,6 +13,7 @@ import type { Job } from 'bullmq';
 import type { DragonData } from '../types/DragonTypes';
 import { attributes, phase } from '../utils/dragons';
 import fsExists from '../server/utils/fsExists';
+// @ts-expect-error Unfortunately there are no types.
 import WebP from 'node-webpmux';
 
 export default async function bannerGen(job: Job<WorkerInput, WorkerFinished>) {

--- a/workers/shareScrollWorkerTypes.ts
+++ b/workers/shareScrollWorkerTypes.ts
@@ -78,7 +78,7 @@ const hexValue = z.string().regex(/^#[0-9a-f]{6}$/);
 
 export const querySchema = z
   .object({
-    ext: z.union([z.literal('.gif'), z.literal('.webp')]).default('.gif'),
+    ext: z.union([z.literal('.gif'), z.literal('.webp')]).default('.webp'),
     stats: z
       .union([z.literal('dragons'), z.literal('garden')])
       .default('garden'),


### PR DESCRIPTION
- drops support for gif
- exports the banners as animated webp
- saves about a second of processing time
