### PR TITLE
drop click record job from 72 hours to 12

### DIFF
--- a/server/routes/view/[id].ts
+++ b/server/routes/view/[id].ts
@@ -23,10 +23,10 @@ export default defineEventHandler(async (event) => {
       },
       {
         removeOnComplete: {
-          age: 1000 * 60 * 60 * 24 * 3,
+          age: 1000 * 60 * 60 * 12,
         },
         removeOnFail: {
-          age: 1000 * 60 * 60 * 24 * 3,
+          age: 1000 * 60 * 60 * 12,
         },
       }
     );


### PR DESCRIPTION
The initial 3 days was chosen as a safety measure that turns out not to be needed or used. Reducing it to 12 will help with redis memory usage.